### PR TITLE
Fixes a segmentation fault caused by a missing copy constructor and separates debug flags from default ones in Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,15 @@
 CXX=g++
-CXXFLAGS=-Wall -Wextra -Wshadow -std=c++17 -O2 -fno-exceptions -fno-rtti -g -Isrc -Isrc/client
+CXXFLAGS=-Wall -Wextra -Wshadow -std=c++17 -O2 -fno-exceptions -fno-rtti -Isrc -Isrc/client
 ifdef WINDOWS
 LIBS=-lopengl32 -lglu32 -llua -lintl
 else
 LIBS=-lGL -lGLU -llua5.4
 endif
 LIBS:=$(LIBS) -lpng -lSDL2 -lSDL2_ttf -lm -pthread
+
+ifdef DEBUG
+CXXFLAGS:=${CXXFLAGS} -fsanitize=address -g
+endif
 
 OBJS=$(shell find . -type f -iname '*.cpp')
 OBJS:=$(patsubst ./src/%.cpp,./obj/%.o,$(OBJS))

--- a/src/lua.cpp
+++ b/src/lua.cpp
@@ -1,4 +1,3 @@
-#include <lua5.4/lua.h>
 #ifdef WINDOWS
 #include <lua.hpp>
 #else

--- a/src/texture.hpp
+++ b/src/texture.hpp
@@ -10,7 +10,8 @@ public:
 	Texture() {};
 	Texture(const char * path);
 	~Texture();
-	
+	Texture(const Texture& tex) : buffer(tex.buffer) {};
+
 	uint32_t * buffer;
 	size_t width;
 	size_t height;


### PR DESCRIPTION
* Fixes a segmentation fault caused by a missing copy constructor
* Also changes the Makefile to separate debug flags from default ones