### PR TITLE
Fixed pathfinding

### DIFF
--- a/src/pathfinding.cpp
+++ b/src/pathfinding.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <unordered_map>
 #include <unordered_set>
+#include <iostream>
 #include <algorithm>
 
 /**
@@ -20,29 +21,19 @@ bool coord_in_bounds(const World& world, int x, int y) {
 std::vector<Tile *> generate_neighbors(const World& world, Tile * tile) {
 	std::vector<Tile *> result;
 	
-	for(size_t i = -1; i <= 1; i++) {
-		for(size_t j = -1; j <= 1; j++) {
+	for(int i = -1; i <= 1; i++) {
+		for(int j = -1; j <= 1; j++) {
+			
 			// Skip middle
 			if(i == 0 && j == 0)
 				continue;
-			
-			if(coord_in_bounds(world, tile->x + i, tile->y + j)) {
-				// Wrap x east to west
-				size_t x = (tile->x + i);
-				
-				// Adjust x, allow wrapping
-				if(x < 0) {
-					x = world.width + x;
-				} else if(x >= world.width) {
-					x %= world.width;
-				}
-				
-				size_t index = x + (tile->y + j) * world.width;
-				Tile * neighbour = &world.tiles[index];
-				if(neighbour->elevation > world.sea_level) {
-					result.push_back(neighbour);
-				}
+		
+			size_t index = (tile->x + i) + (tile->y + j) * world.width;
+			Tile * neighbour = &world.tiles[index];
+			if(neighbour->elevation > world.sea_level) {
+				result.push_back(neighbour);
 			}
+			
 		}
 	}
 	return result;
@@ -53,7 +44,9 @@ std::vector<Tile *> generate_neighbors(const World& world, Tile * tile) {
  * considering only x and y (ignoring elevation)
  */
 float euclidean_distance(Tile * t1, Tile * t2) {
-	return std::hypot(t1->x - t2->x, t1->y - t2->y);
+	int x_diff = t1->x - t2->x;
+	int y_diff = t1->y - t2->y;
+	return std::sqrt(x_diff * x_diff + y_diff * y_diff);
 }
 
 /**
@@ -65,13 +58,13 @@ float tile_cost(Tile * t1, Tile * t2) {
 	int y_diff = t1->y - t2->y;
 	
 	// Maximum elevation difference accounts to same cost as one jump in x or y direction (1.0)
-	float elev_diff = (int)t1->elevation - (int)t2->elevation / 128.f;
+	float elev_diff = ((int)t1->elevation - (int)t2->elevation) / 128.f;
 	
 	// Base distance is euclidean distance in x, y and elevation
 	float distance = std::sqrt(x_diff * x_diff + y_diff * y_diff + elev_diff * elev_diff);
 	
 	// Calculate average infrastructure level between the two tiles
-	float avg_infra = ((t1->infra_level + t2->infra_level) / 2.f) + 1.f;
+	float avg_infra = ((t1->infra_level + t2->infra_level) / 2.f);
 	
 	// Cost modifier from infrastructure scales linearly with infrastructure
 	// with 1.0 cost modifier at max infra and 5.0 modifier at 0 infra
@@ -87,6 +80,7 @@ float tile_cost(Tile * t1, Tile * t2) {
 }
 
 std::vector<Tile *> find_path(const World& world, Tile * start, Tile * end) {
+	
 	if (start->elevation <= world.sea_level && end->elevation <= world.sea_level) {
 		return std::vector<Tile *>();
 	}
@@ -101,11 +95,15 @@ std::vector<Tile *> find_path(const World& world, Tile * start, Tile * end) {
 	std::unordered_set<Tile *> visited;
 	
 	// Priority queue based on cost
-	std::priority_queue<std::pair<float, Tile *>> queue;
+	std::priority_queue<
+		std::pair<float, Tile *>,
+		std::vector<std::pair<float, Tile *>>,
+		std::greater<std::pair<float, Tile *>>
+	> queue;
 	
 	cost_map[start] = 0.f;
 	queue.push({0.f, start});
-	
+
 	while(!queue.empty()) {
 		Tile * current = queue.top().second;
 		queue.pop();
@@ -126,7 +124,7 @@ std::vector<Tile *> find_path(const World& world, Tile * start, Tile * end) {
 			if(visited.count(neighbor))
 				continue;
 			
-			float cost = cost_map[current] + euclidean_distance(current, neighbor);
+			float cost = cost_map[current] + tile_cost(current, neighbor);
 			// If we found a new tile or a shorter path to a previously found tile
 			if(!cost_map.count(neighbor) || cost < cost_map[neighbor]) {
 				cost_map[neighbor] = cost;
@@ -136,7 +134,7 @@ std::vector<Tile *> find_path(const World& world, Tile * start, Tile * end) {
 			}
 		}
 	}
-	
+
 	std::vector<Tile *> path;
 	
 	// Unwind path and reverse

--- a/src/pathfinding.cpp
+++ b/src/pathfinding.cpp
@@ -4,7 +4,6 @@
 #include <cmath>
 #include <unordered_map>
 #include <unordered_set>
-#include <iostream>
 #include <algorithm>
 
 /**


### PR DESCRIPTION
Pathfinding seems to work now. 

- Fixed priority queue sorting in the wrong order.
- std::hypot was behaving in a weird way, I replaced it with explicit hypotenuse calculation and that fixed the heuristic.
- Also removed unnecessary wrapping and bounds checks for now.